### PR TITLE
Close #9 - Update android intent scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ While many social media sites fail to download assets properly, on Android you c
 - ❌ 🔇 - Fails to download file without any indication to user (silent)
 - ❌ 📝 - Fails but provides a note
 - ❌ 🖼️ - Opens image in browser but doesn't download or provide feedback on how to download
-- Intent link escape (opens link in default browser instead of in-app) - `intent://example.com#Intent;scheme=https;end`
+
+Intent link escape (opens link in default browser instead of in-app) - `intent://example.com#Intent;scheme=https;end`
+
 - Last updated: Oct 16, 2024
 
 | App (Android)     | Default browser / Tab View | Detect In-app  | Blob Url download | Static asset download | Intent link escape |
@@ -55,34 +57,33 @@ While many social media sites fail to download assets properly, on Android you c
 
 ### iOS
 
-🚧 Area needs updating
-There are some escape methods available especially to Safari - use [inappdebugger.com](https://inappdebugger.com) to test out methods
+There are some escape methods available namely to Safari - use [inappdebugger.com](https://inappdebugger.com) to test out methods. However there is no Apple-approved way to escape in-app browsers to the default browser in contrast to Android intent links.
 
-=======
-
-There is no reliable way to exit in-app browsers on iOS. **And even when a user is prompted to select a browser to open a given link from an app, Safari in the pared down SFSafariViewController provides a uniquely bad downloading experience.** The user is shown the file details via text but one must click on "More..." then scroll below the fold to "Save to image" to download the file. This bizarre behavior is captured on the first row of the table below.
+SFSVC (Safari View Controller) - akin to Tab View on Android - is used by many apps to open links over older in-app browsers. This view is very confusing to users. So much so that users give up trying to download assets. Apple is encouraging and pushing its app developers to use SFSVC in their apps. It also unlike Tab View on Android does not respect the user's default browser.
 
 - SFSVC - SFSafariViewController
 - ❌ 🔇 - Fails to download file without any indication to user.
 - ❌ 📝 - Fails but provides a note
 - ❌ 🖼️ - Opens image in browser but doesn't download or provide feedback on how to download
-- ❌ 🤮 - SFSVC - You can download in this view after clicking "More...", scroll, click "Save image" or file. Unnecessarily convoluted UX compared to Safari.
+- ❌ 🤮 - SFSVC - You can download in this view after clicking "More...", scroll, click "Save image" or file. Unnecessarily convoluted UX compared to Safari. User complaints are high.
+
+🚧 Area needs updating (escape link table and download functionality)
 
 - Safari search link - `x-web-search://?site:example.com`
 - Browser app link - In example Chrome: `googlechromes://example.com`
 - Last updated: Feb 7, 2024
 
-| App (iPhone)      | Uses default browser | Detect In-app                          | Blob Url download           | Static asset download       | Safari search link  | Browser app link    |
-| ----------------- | -------------------- | -------------------------------------- | --------------------------- | --------------------------- | ------------------- | ------------------- |
-| SFSVC Overview    | ❌ SFSVC             | ❌                                     | ❌ 🤮                       | ❌ 🤮                       | ❌                  | ✅                  |
-| TikTok            | ❌                   | ✅                                     | ❌ 📝                       | ❌ 📝                       | ✅                  | ❌                  |
-| Threads           | ❌ SFSVC             | ❌                                     | ❌ 🤮                       | ❌ 🤮                       | ❌                  | ✅                  |
-| Facebook          | ❌                   | ✅                                     | ❌ 📝                       | ❌ 📝                       | ✅                  | ✅                  |
-| Instagram         | ❌                   | ✅                                     | ❌ 📝                       | ❌ 📝                       | ❌                  | ✅                  |
-| Messenger         | ❌                   | ✅                                     | ❌ 🔇                       | ❌ 📝                       | ✅                  | ✅                  |
-| SnapChat          | ❌                   | ✅                                     | ❌ 🔇                       | ❌ 📝                       | ✅                  | ✅                  |
-| LinkedIn          | ❌                   | ✅                                     | ❌ 🔇                       | ❌ 📝                       | ✅                  | ✅                  |
-| Twitter           | ❌ SFSVC             | ❌                                     | ❌ 🤮                       | ❌ 🤮                       | ❌                  | ✅                  |
-| Gmail             | ✅                   | NA                                     | Don't select Safari (SFSVC) | Don't select Safari (SFSVC) | Selection dependent | Selection dependent |
-| YouTube           | ✅                   | NA                                     | Don't select Safari (SFSVC) | Don't select Safari (SFSVC) | Selection dependent | Selection dependent |
-| Google Search App | ❌                   | ❌ not yet, but UA is searchable (GSA) | ❌ 🔇                       | ✅                          | ✅                  | ✅                  |
+| App (iPhone)                                                                                          | Uses default browser | Detect In-app                          | Blob Url download           | Static asset download       | Safari search link  | Browser app link    |
+| ----------------------------------------------------------------------------------------------------- | -------------------- | -------------------------------------- | --------------------------- | --------------------------- | ------------------- | ------------------- |
+| SFSafariViewController - Selecting "Safari" icon to open a link from an app like in Gmail or Twitter. | ❌ SFSVC             | ❌                                     | ❌ 🤮                       | ❌ 🤮                       | ❌                  | ✅                  |
+| TikTok                                                                                                | ❌                   | ✅                                     | ❌ 📝                       | ❌ 📝                       | ✅                  | ❌                  |
+| Threads                                                                                               | ❌ SFSVC             | ❌                                     | ❌ 🤮                       | ❌ 🤮                       | ❌                  | ✅                  |
+| Facebook                                                                                              | ❌                   | ✅                                     | ❌ 📝                       | ❌ 📝                       | ✅                  | ✅                  |
+| Instagram                                                                                             | ❌                   | ✅                                     | ❌ 📝                       | ❌ 📝                       | ❌                  | ✅                  |
+| Messenger                                                                                             | ❌                   | ✅                                     | ❌ 🔇                       | ❌ 📝                       | ✅                  | ✅                  |
+| SnapChat                                                                                              | ❌                   | ✅                                     | ❌ 🔇                       | ❌ 📝                       | ✅                  | ✅                  |
+| LinkedIn                                                                                              | ❌                   | ✅                                     | ❌ 🔇                       | ❌ 📝                       | ✅                  | ✅                  |
+| Twitter                                                                                               | ❌ SFSVC             | ❌                                     | ❌ 🤮                       | ❌ 🤮                       | ❌                  | ✅                  |
+| Gmail                                                                                                 | ✅                   | NA                                     | Don't select Safari (SFSVC) | Don't select Safari (SFSVC) | Selection dependent | Selection dependent |
+| YouTube                                                                                               | ✅                   | NA                                     | Don't select Safari (SFSVC) | Don't select Safari (SFSVC) | Selection dependent | Selection dependent |
+| Google Search App                                                                                     | ❌                   | ❌ not yet, but UA is searchable (GSA) | ❌ 🔇                       | ✅                          | ✅                  | ✅                  |

--- a/README.md
+++ b/README.md
@@ -27,52 +27,54 @@ Test common in-app issues
 
 ## Android
 
-While many social media sites fail to download assets properly, on Android you can use the intent link reliably to escape.
+While many social media sites fail to download assets properly, on Android you can use the intent link reliably to escape except for WeChat + TikTok.
 
-- ❌ Silent - Fails to download file without any indication to user.
-- ❌ With note - Fails but provides some feedback to user.
-- ❌ Opens file in default browser - Unexpected behavior. Continues to confuses user on how to download file.
-- Intent link escape (opens link in default browser instead of in-app) - `intent:https://example.com#Intent;end`
-- Last updated: Feb 7, 2024
-- "\*" I have to come back to these some are using the default browser iin-app view of sorts and some are using Chrome in an in-app
+- ❌ 🔇 - Fails to download file without any indication to user (silent)
+- ❌ 📝 - Fails but provides a note
+- ❌ 🖼️ - Opens image in browser but doesn't download or provide feedback on how to download
+- Intent link escape (opens link in default browser instead of in-app) - `intent://example.com#Intent;scheme=https;end`
+- Last updated: Oct 16, 2024
 
-| App (Android)     | Uses default browser | Detect In-app | On-the-fly download | Static asset download            | Intent link escape |
-| ----------------- | -------------------- | ------------- | ------------------- | -------------------------------- | ------------------ |
-| TikTok            | ❌                   | ✅            | ❌ Silent           | ❌ Silent                        | ✅                 |
-| Threads           | ❌                   | ✅            | ❌ Silent           | ❌ Opens file in default browser | ✅                 |
-| Facebook          | ❌                   | ✅            | ❌ With note        | ❌ Opens file in default browser | ✅                 |
-| Instagram         | ❌                   | ✅            | ❌ With note        | ❌ Opens file in default browser | ✅                 |
-| Messenger         | ❌                   | ✅            | ❌ With note        | ❌ Opens file in default browser | ✅                 |
-| SnapChat          | \*                   | NA            | ✅                  | ✅                               | NA                 |
-| LinkedIn          | \*                   | NA            | ✅                  | ✅                               | NA                 |
-| Twitter           | \*                   | NA            | ✅                  | ✅                               | NA                 |
-| Gmail             | \*                   | NA            | ✅                  | ✅                               | NA                 |
-| YouTube           | \*                   | NA            | ✅                  | ✅                               | NA                 |
-| Google Search App | \*                   | NA            | ✅                  | ✅                               | NA                 |
-| GroupMe           | \*                   | NA            | ✅                  | ✅                               | NA                 |
+| App (Android)     | Default browser / Tab View | Detect In-app  | Blob Url download | Static asset download | Intent link escape |
+| ----------------- | -------------------------- | -------------- | ----------------- | --------------------- | ------------------ |
+| WeChat            | ❌                         | ✅             | ❌ 📝             | ❌ 📝                 | ❌ does not work   |
+| Telegram          | ❌                         | ❌ in progress | ❌ 📝             | ✅                    | ✅                 |
+| Line              | ❌                         | ✅             | ❌ 📝             | ❌ Fails to load      | ✅                 |
+| TikTok            | ❌                         | ✅             | ❌ 🔇             | ❌ 🔇                 | ❌ not dependable  |
+| Threads           | ❌                         | ✅             | ❌ 📝             | ❌ 🖼️                 | ✅                 |
+| Facebook          | ❌                         | ✅             | ❌ 📝             | ❌ 🖼️                 | ✅                 |
+| Instagram         | ❌                         | ✅             | ❌ 📝             | ❌ 🖼️                 | ✅                 |
+| Messenger         | ❌                         | ✅             | ❌ 📝             | ❌ 🖼️                 | ✅                 |
+| SnapChat          | ✅                         | NA             | NA                | NA                    | NA                 |
+| LinkedIn          | ✅                         | NA             | NA                | NA                    | NA                 |
+| Twitter           | ✅                         | NA             | NA                | NA                    | NA                 |
+| Gmail             | ✅                         | NA             | NA                | NA                    | NA                 |
+| YouTube           | ✅                         | NA             | NA                | NA                    | NA                 |
+| Google Search App | ✅                         | NA             | NA                | NA                    | NA                 |
+| GroupMe           | ✅                         | NA             | NA                | NA                    | NA                 |
 
 ### iOS
 
 There is no reliable way to exit in-app browsers on iOS. **And even when a user is prompted to select a browser to open a given link from an app, Safari in the pared down SFSafariViewController provides a uniquely bad downloading experience.** The user is shown the file details via text but one must click on "More..." then scroll below the fold to "Save to image" to download the file. This bizarre behavior is captured on the first row of the table below.
 
-- ❌ Silent - Fails to download file without any indication to user.
+- ❌ 🔇 - Fails to download file without any indication to user.
 - ❌ Opens file in in-app browser - Provides no easy way to download
 - ❌ Shows file, but have to... - You can technically download in this view after click ("More..."), scroll, click ("Save image" or file) in SFSafariViewController but the UX is exceedingly bad and not on-par with Safari or any other browser experience that I believe it doesn't fulfill the capabilities of what is expected from a web download link.
 - Safari search link - `x-web-search://?site:example.com`
 - Browser app link - In example Chrome: `googlechromes://example.com`
 - Last updated: Feb 7, 2024
 
-| App (iPhone)                                                                                          | Uses default browser      | Detect In-app                          | On-the-fly download                                                    | Static asset download                                                  | Safari search link         | Browser app link           |
+| App (iPhone)                                                                                          | Uses default browser      | Detect In-app                          | Blob Url download                                                      | Static asset download                                                  | Safari search link         | Browser app link           |
 | ----------------------------------------------------------------------------------------------------- | ------------------------- | -------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------- | -------------------------- | -------------------------- |
 | SFSafariViewController - Selecting "Safari" icon to open a link from an app like in Gmail or Twitter. | ❌ SFSafariViewController | ❌                                     | ❌ Shows file, but have to click "More..." then scroll to "Save image" | ❌ Shows file, but have to click "More..." then scroll to "Save image" | ❌                         | ✅                         |
 | TikTok                                                                                                | ❌                        | ✅                                     | ❌ Opens file in in-app browser                                        | ❌ Opens file in in-app browser                                        | ✅                         | ❌                         |
 | Threads                                                                                               | ❌ SFSafariViewController | ❌                                     | ❌ Shows file, but have to click "More..." then scroll to "Save image" | ❌ Shows file, but have to click "More..." then scroll to "Save image" | ❌                         | ✅                         |
 | Facebook                                                                                              | ❌                        | ✅                                     | ❌ Opens file in in-app browser                                        | ❌ Opens file in in-app browser                                        | ✅                         | ✅                         |
 | Instagram                                                                                             | ❌                        | ✅                                     | ❌ Opens file in in-app browser                                        | ❌ Opens file in in-app browser                                        | ❌                         | ✅                         |
-| Messenger                                                                                             | ❌                        | ✅                                     | ❌ Silent                                                              | ❌ Opens file in in-app browser                                        | ✅                         | ✅                         |
-| SnapChat                                                                                              | ❌                        | ✅                                     | ❌ Silent                                                              | ❌ Opens file in in-app browser                                        | ✅                         | ✅                         |
-| LinkedIn                                                                                              | ❌                        | ✅                                     | ❌ Silent                                                              | ❌ Opens file in in-app browser                                        | ✅                         | ✅                         |
+| Messenger                                                                                             | ❌                        | ✅                                     | ❌ 🔇                                                                  | ❌ Opens file in in-app browser                                        | ✅                         | ✅                         |
+| SnapChat                                                                                              | ❌                        | ✅                                     | ❌ 🔇                                                                  | ❌ Opens file in in-app browser                                        | ✅                         | ✅                         |
+| LinkedIn                                                                                              | ❌                        | ✅                                     | ❌ 🔇                                                                  | ❌ Opens file in in-app browser                                        | ✅                         | ✅                         |
 | Twitter                                                                                               | ❌ SFSafariViewController | ❌                                     | ❌ Shows file, but have to click "More..." then scroll to "Save image" | ❌ Shows file, but have to click "More..." then scroll to "Save image" | ❌                         | ✅                         |
 | Gmail                                                                                                 | ✅                        | NA                                     | As long as you don't select Safari icon (SFSafariViewController)       | As long as you don't select Safari icon (SFSafariViewController)       | Selected browser dependent | Selected browser dependent |
 | YouTube                                                                                               | ✅                        | NA                                     | As long as you don't select Safari icon (SFSafariViewController)       | As long as you don't select Safari icon (SFSafariViewController)       | Selected browser dependent | Selected browser dependent |
-| Google Search App                                                                                     | ❌                        | ❌ not yet, but UA is searchable (GSA) | ❌ Silent                                                              | ✅                                                                     | ✅                         | ✅                         |
+| Google Search App                                                                                     | ❌                        | ❌ not yet, but UA is searchable (GSA) | ❌ 🔇                                                                  | ✅                                                                     | ✅                         | ✅                         |

--- a/README.md
+++ b/README.md
@@ -55,26 +55,34 @@ While many social media sites fail to download assets properly, on Android you c
 
 ### iOS
 
+🚧 Area needs updating
+There are some escape methods available especially to Safari - use [inappdebugger.com](https://inappdebugger.com) to test out methods
+
+=======
+
 There is no reliable way to exit in-app browsers on iOS. **And even when a user is prompted to select a browser to open a given link from an app, Safari in the pared down SFSafariViewController provides a uniquely bad downloading experience.** The user is shown the file details via text but one must click on "More..." then scroll below the fold to "Save to image" to download the file. This bizarre behavior is captured on the first row of the table below.
 
+- SFSVC - SFSafariViewController
 - ❌ 🔇 - Fails to download file without any indication to user.
-- ❌ Opens file in in-app browser - Provides no easy way to download
-- ❌ Shows file, but have to... - You can technically download in this view after click ("More..."), scroll, click ("Save image" or file) in SFSafariViewController but the UX is exceedingly bad and not on-par with Safari or any other browser experience that I believe it doesn't fulfill the capabilities of what is expected from a web download link.
+- ❌ 📝 - Fails but provides a note
+- ❌ 🖼️ - Opens image in browser but doesn't download or provide feedback on how to download
+- ❌ 🤮 - SFSVC - You can download in this view after clicking "More...", scroll, click "Save image" or file. Unnecessarily convoluted UX compared to Safari.
+
 - Safari search link - `x-web-search://?site:example.com`
 - Browser app link - In example Chrome: `googlechromes://example.com`
 - Last updated: Feb 7, 2024
 
-| App (iPhone)                                                                                          | Uses default browser      | Detect In-app                          | Blob Url download                                                      | Static asset download                                                  | Safari search link         | Browser app link           |
-| ----------------------------------------------------------------------------------------------------- | ------------------------- | -------------------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------- | -------------------------- | -------------------------- |
-| SFSafariViewController - Selecting "Safari" icon to open a link from an app like in Gmail or Twitter. | ❌ SFSafariViewController | ❌                                     | ❌ Shows file, but have to click "More..." then scroll to "Save image" | ❌ Shows file, but have to click "More..." then scroll to "Save image" | ❌                         | ✅                         |
-| TikTok                                                                                                | ❌                        | ✅                                     | ❌ Opens file in in-app browser                                        | ❌ Opens file in in-app browser                                        | ✅                         | ❌                         |
-| Threads                                                                                               | ❌ SFSafariViewController | ❌                                     | ❌ Shows file, but have to click "More..." then scroll to "Save image" | ❌ Shows file, but have to click "More..." then scroll to "Save image" | ❌                         | ✅                         |
-| Facebook                                                                                              | ❌                        | ✅                                     | ❌ Opens file in in-app browser                                        | ❌ Opens file in in-app browser                                        | ✅                         | ✅                         |
-| Instagram                                                                                             | ❌                        | ✅                                     | ❌ Opens file in in-app browser                                        | ❌ Opens file in in-app browser                                        | ❌                         | ✅                         |
-| Messenger                                                                                             | ❌                        | ✅                                     | ❌ 🔇                                                                  | ❌ Opens file in in-app browser                                        | ✅                         | ✅                         |
-| SnapChat                                                                                              | ❌                        | ✅                                     | ❌ 🔇                                                                  | ❌ Opens file in in-app browser                                        | ✅                         | ✅                         |
-| LinkedIn                                                                                              | ❌                        | ✅                                     | ❌ 🔇                                                                  | ❌ Opens file in in-app browser                                        | ✅                         | ✅                         |
-| Twitter                                                                                               | ❌ SFSafariViewController | ❌                                     | ❌ Shows file, but have to click "More..." then scroll to "Save image" | ❌ Shows file, but have to click "More..." then scroll to "Save image" | ❌                         | ✅                         |
-| Gmail                                                                                                 | ✅                        | NA                                     | As long as you don't select Safari icon (SFSafariViewController)       | As long as you don't select Safari icon (SFSafariViewController)       | Selected browser dependent | Selected browser dependent |
-| YouTube                                                                                               | ✅                        | NA                                     | As long as you don't select Safari icon (SFSafariViewController)       | As long as you don't select Safari icon (SFSafariViewController)       | Selected browser dependent | Selected browser dependent |
-| Google Search App                                                                                     | ❌                        | ❌ not yet, but UA is searchable (GSA) | ❌ 🔇                                                                  | ✅                                                                     | ✅                         | ✅                         |
+| App (iPhone)      | Uses default browser | Detect In-app                          | Blob Url download           | Static asset download       | Safari search link  | Browser app link    |
+| ----------------- | -------------------- | -------------------------------------- | --------------------------- | --------------------------- | ------------------- | ------------------- |
+| SFSVC Overview    | ❌ SFSVC             | ❌                                     | ❌ 🤮                       | ❌ 🤮                       | ❌                  | ✅                  |
+| TikTok            | ❌                   | ✅                                     | ❌ 📝                       | ❌ 📝                       | ✅                  | ❌                  |
+| Threads           | ❌ SFSVC             | ❌                                     | ❌ 🤮                       | ❌ 🤮                       | ❌                  | ✅                  |
+| Facebook          | ❌                   | ✅                                     | ❌ 📝                       | ❌ 📝                       | ✅                  | ✅                  |
+| Instagram         | ❌                   | ✅                                     | ❌ 📝                       | ❌ 📝                       | ❌                  | ✅                  |
+| Messenger         | ❌                   | ✅                                     | ❌ 🔇                       | ❌ 📝                       | ✅                  | ✅                  |
+| SnapChat          | ❌                   | ✅                                     | ❌ 🔇                       | ❌ 📝                       | ✅                  | ✅                  |
+| LinkedIn          | ❌                   | ✅                                     | ❌ 🔇                       | ❌ 📝                       | ✅                  | ✅                  |
+| Twitter           | ❌ SFSVC             | ❌                                     | ❌ 🤮                       | ❌ 🤮                       | ❌                  | ✅                  |
+| Gmail             | ✅                   | NA                                     | Don't select Safari (SFSVC) | Don't select Safari (SFSVC) | Selection dependent | Selection dependent |
+| YouTube           | ✅                   | NA                                     | Don't select Safari (SFSVC) | Don't select Safari (SFSVC) | Selection dependent | Selection dependent |
+| Google Search App | ❌                   | ❌ not yet, but UA is searchable (GSA) | ❌ 🔇                       | ✅                          | ✅                  | ✅                  |

--- a/src/sections/InappEscape.tsx
+++ b/src/sections/InappEscape.tsx
@@ -131,7 +131,7 @@ export const InappEscape = () => {
               {
                 type: "link",
                 title: "Open in default browser",
-                href: "intent:https://example.com#Intent;end",
+                href: "intent://example.com#Intent;scheme=https;end",
               },
             ]}
           />


### PR DESCRIPTION
Telegram would not respond to other android intent scheme - trying this flavor of it out and testing before suggesting + merging.

Closes #9 

Change
`intent:https://example.com#Intent;end`

To
`intent://example.com#Intent;scheme=https;end`

New link works in most inapp browsers except in WeChat + Tabs browser. (which is ok since tab browsers are the default browser)

Prior link worked in most inapp browsers except for Telegram and the above mentioned WeChat + Tabs.