### PR TITLE
Added link for testing Instagram IOS feature for escaping in app browser

### DIFF
--- a/src/sections/InappEscape.tsx
+++ b/src/sections/InappEscape.tsx
@@ -76,6 +76,13 @@ export const InappEscape = () => {
               },
               {
                 type: "link",
+                title: "Instagram",
+                href:`instagram://extbrowser/?url=${encodeURIComponent(
+                  "https://example.com",
+                )}`,
+              },
+              {
+                type: "link",
                 title: "Safari search",
                 href: "x-web-search://?site:example.com",
               },


### PR DESCRIPTION
# Escaping the Instagram In-App Browser

## Solution

An undocumented Instagram URL scheme appears to allow links to open outside Instagram’s in-app browser. Several bio-link tools already seem to use this approach.

This PR adds a simple test link using the following URL format:

```text
instagram://extbrowser/?url=<encoded-url>
```

## Testing

Verified on Instagram 445.0:

* iOS 27
* Android 16


Fixes shalanah/inapp-debugger#22